### PR TITLE
urgent: fix workflows

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -72,12 +72,14 @@ jobs:
         id: check-rmd
         working-directory: lesson
         run: |
-          echo "::set-output name=count::$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})"
+          echo "count=$(shopt -s nullglob; files=($(find . -iname '*.Rmd')); echo ${#files[@]})" >> $GITHUB_OUTPUT
 
       - name: Set up R
         if: steps.check-rmd.outputs.count != 0
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
+          use-public-rspm: true
+          install-r: false
           r-version: 'release'
 
       - name: Install needed packages


### PR DESCRIPTION
This pull request updates the workflows for this lesson.

There are two items that are changed:

1. r-lib/actions/setup-r now uses `@v2` instead of `@master` as the default tag
2. the `set-output` GHA workflow command has been updated as it was deprecated.

see https://github.com/carpentries/styles/issues/641 for details

If you have any questions, contact @zkamvar